### PR TITLE
Support for iOS 5.1

### DIFF
--- a/UAAppReviewManager.podspec
+++ b/UAAppReviewManager.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source                = { :git => "https://github.com/UrbanApps/UAAppReviewManager.git", :tag => s.version.to_s }
   s.source_files          = "UAAppReviewManager.{h,m}"
   s.ios.resource_bundles  = { 'UAAppReviewManager-iOS' => ['Localization/*.lproj'] }
-  s.mac.resource_bundles  = { 'UAAppReviewManager-OSX' => ['Localization/*.lproj'] }
+  s.osx.resource_bundles  = { 'UAAppReviewManager-OSX' => ['Localization/*.lproj'] }
 end


### PR DESCRIPTION
Support for iOS 5.1 by using weak_frameworks for StoreKit. The code already check before opening the store kit if the class exist so the standard method (openURL) will always be used on iOS5.1.
Tested in simulator with iOS 5.1, iOS 6.1 and iOS 7

Also fixed podspec validation by changing s.mac.resource_bundles for s.osx.resource_bundles
