### PR TITLE
changed iOS7 Review URL to go directly to review page & fixed broken cancel button

### DIFF
--- a/UAAppReviewManager.m
+++ b/UAAppReviewManager.m
@@ -812,7 +812,7 @@ static NSString * const reviewURLTemplate                   = @"macappstore://it
 													   delegate:self
 											  cancelButtonTitle:self.cancelButtonTitle
 											  otherButtonTitles:self.remindButtonTitle, self.rateButtonTitle, nil];
-    alertView.cancelButtonIndex = -1;
+    alertView.cancelButtonIndex = 0;
 	self.ratingAlert = alertView;
     [alertView show];
 	


### PR DESCRIPTION
App Store URL: Can probably do equivalent stuff on previous iOS versions too. Only changing iOS 7 for now since I haven't tested others. 
